### PR TITLE
adds fzf recommended dependency

### DIFF
--- a/unison-language.rb
+++ b/unison-language.rb
@@ -2,6 +2,7 @@ class UnisonLanguage < Formula
   desc "The Unison Language and Codebase Manager."
   homepage "https://unisonweb.org"
   license "MIT"
+  depends_on "fzf" => :recommended
 
   version "1.0.M2k"
   if OS.mac?


### PR DESCRIPTION
Adds a recommended dependency to the homebrew formula. 

I did not opt to bump the version here, as nothing about the binary being built changed, but could be convinced otherwise. 

## Testing: 

locally built with `brew reinstall --debug  --build-from-source ./unison-language.rb`

published a local version of the ucm with version `m2k-test` and then ran the executable against an existing codebase. 

```
$  /opt/homebrew/Cellar/unison-language/1.0.M2k-test/ucm --codebase newTest
```

No issues. 

Check dependencies: 

```
brew info unison-language.rb

==> Dependencies
Recommended: fzf ✔
==> Options
--without-fzf
	Build without fzf support
--HEAD
	Install HEAD version
```

You can build without fzf with a flag to brew. 

