### PR TITLE
Add dispatchable task to automate brew upgrade

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: "release_version"
+name: "release"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,15 +22,16 @@ jobs:
           for (( i = 0; i < $tries; i++ )); do
             # It's possible for this job to be kicked off before the release has been created,
             # We'll keep trying for 2 hrs, since Windows can take a long time to build.
-            if gh release download --repo unisonweb/unison release/${{inputs.version}} ; then
+            if gh release download --repo unisonweb/unison "release/${{inputs.version}}"  --pattern "ucm-*" ; then
               break
+            fi
             echo "Couldn't download release artifacts, release may not yet exist. Trying again in 5 minutes."
             sleep 300 # If we failed, wait for 5 minutes
           done
-          linux_sha=$(cat ucm-linux.tar.gz | shasum -a 256 | cut -f1 -d" ")
-          macos_sha=$(cat ucm-macos.tar.gz | shasum -a 256 | cut -f1 -d" ")
+          linux_sha=$(shasum -a 256 < ucm-linux.tar.gz | cut -f1 -d" ")
+          macos_sha=$(shasum -a 256 < ucm-macos.tar.gz | cut -f1 -d" ")
           # Generate formula with correct version and SHAs.
-          cat unison-language.rb.template | sed "s/{{macos_sha}}/${macos_sha}/g;s/{{linux_sha}}/${linux_sha}/g;s/{{version}}/${version}/g;" > unison-language.rb
+          sed "s/{{macos_sha}}/${macos_sha}/g;s/{{linux_sha}}/${linux_sha}/g;s/{{version}}/${version}/g;" < unison-language.rb.template > unison-language.rb
           git add unison-language.rb
           git commit -m "release/${version}"
           git push origin master

--- a/.github/workflows/release_version.yaml
+++ b/.github/workflows/release_version.yaml
@@ -16,10 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: make download dir
-        run: "mkdir /tmp/ucm"
-
-      - name: "download artifacts"
+      - name: "Download artifacts and bump homebrew version"
         run: |
           tries=24
           for (( i = 0; i < $tries; i++ )); do
@@ -32,5 +29,8 @@ jobs:
           done
           linux_sha=$(cat ucm-linux.tar.gz | shasum -a 256 | cut -f1 -d" ")
           macos_sha=$(cat ucm-macos.tar.gz | shasum -a 256 | cut -f1 -d" ")
-          cat unison-language.rb.template | sed -n "{s/{{macos_sha}}/${macos_sha}/g;}" > out
-
+          # Generate formula with correct version and SHAs.
+          cat unison-language.rb.template | sed "s/{{macos_sha}}/${macos_sha}/g;s/{{linux_sha}}/${linux_sha}/g;s/{{version}}/${version}/g;" > unison-language.rb
+          git add unison-language.rb
+          git commit -m "release/${version}"
+          git push origin master

--- a/.github/workflows/release_version.yaml
+++ b/.github/workflows/release_version.yaml
@@ -1,0 +1,36 @@
+name: "release_version"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release Version'
+        required: true
+        type: string
+
+jobs:
+  update_formula:
+    name: "update_formula"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: make download dir
+        run: "mkdir /tmp/ucm"
+
+      - name: "download artifacts"
+        run: |
+          tries=24
+          for (( i = 0; i < $tries; i++ )); do
+            # It's possible for this job to be kicked off before the release has been created,
+            # We'll keep trying for 2 hrs, since Windows can take a long time to build.
+            if gh release download --repo unisonweb/unison release/${{inputs.version}} ; then
+              break
+            echo "Couldn't download release artifacts, release may not yet exist. Trying again in 5 minutes."
+            sleep 300 # If we failed, wait for 5 minutes
+          done
+          linux_sha=$(cat ucm-linux.tar.gz | shasum -a 256 | cut -f1 -d" ")
+          macos_sha=$(cat ucm-macos.tar.gz | shasum -a 256 | cut -f1 -d" ")
+          cat unison-language.rb.template | sed -n "{s/{{macos_sha}}/${macos_sha}/g;}" > out
+

--- a/unison-language.rb.template
+++ b/unison-language.rb.template
@@ -9,7 +9,7 @@ class UnisonLanguage < Formula
     url "https://github.com/unisonweb/unison/releases/download/release%2F{{version}}/ucm-macos.tar.gz"
     sha256 "{{macos_sha}}"
 
-    head "https://github.com/unisonweb/unison/releases/download/latest-macOS/unison-macOS.tar.gz"
+    head "https://github.com/unisonweb/unison/releases/download/latest/ucm-macos.tar.gz"
   elsif OS.linux?
     url "https://github.com/unisonweb/unison/releases/download/release%2F{{version}}/ucm-linux.tar.gz"
     sha256 "{{linux_sha}}"

--- a/unison-language.rb.template
+++ b/unison-language.rb.template
@@ -1,0 +1,33 @@
+class UnisonLanguage < Formula
+  desc "The Unison Language and Codebase Manager."
+  homepage "https://unisonweb.org"
+  license "MIT"
+  depends_on "fzf" => :recommended
+
+  version "1.0.{{version}}"
+  if OS.mac?
+    url "https://github.com/unisonweb/unison/releases/download/release%2F{{version}}/ucm-macos.tar.gz"
+    sha256 "{{macos_sha}}"
+
+    head "https://github.com/unisonweb/unison/releases/download/latest-macOS/unison-macOS.tar.gz"
+  elsif OS.linux?
+    url "https://github.com/unisonweb/unison/releases/download/release%2F{{version}}/ucm-linux.tar.gz"
+    sha256 "{{linux_sha}}"
+
+    head "https://github.com/unisonweb/unison/releases/download/latest-Linux/unison-Linux.tar.gz"
+  end
+
+  def install
+    prefix.install Dir["*"]
+    bin.install_symlink prefix/"ucm"
+  end
+
+  test do
+    (testpath/"getbase.md").write <<~EOS
+      ```ucm
+      .> pull https://github.com/unisonweb/base:.releases._latest .base
+      ```
+    EOS
+    system "ucm", "transcript", testpath/"getbase.md"
+  end
+end

--- a/unison-language.rb.template
+++ b/unison-language.rb.template
@@ -14,7 +14,7 @@ class UnisonLanguage < Formula
     url "https://github.com/unisonweb/unison/releases/download/release%2F{{version}}/ucm-linux.tar.gz"
     sha256 "{{linux_sha}}"
 
-    head "https://github.com/unisonweb/unison/releases/download/latest-Linux/unison-Linux.tar.gz"
+    head "https://github.com/unisonweb/unison/releases/download/latest/ucm-linux.tar.gz"
   end
 
   def install


### PR DESCRIPTION
I tested this locally, it'll eventually be dispatched from the `make_release.sh` script in the `unison` repo.

See https://github.com/unisonweb/unison/pull/3435 for that