### PR TITLE
Upgrade Fix: Add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ brew install unison-language
 
 ## Troubleshooting
 
-unison-language: SHA256 mismatch fix
-    - `brew untap unisonweb/unison` 
-    - `brew tap unisonweb/unison`
-    - `brew install unison-language`
+unison-language: SHA256 mismatch fix:
+
+- `brew untap unisonweb/unison` 
+- `brew tap unisonweb/unison`
+- `brew install unison-language`

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Install with:
 brew tap unisonweb/unison
 brew install unison-language
 ```
+
+## Troubleshooting
+
+unison-language: SHA256 mismatch fix
+    - `brew untap unisonweb/unison` 
+    - `brew tap unisonweb/unison`
+    - `brew install unison-language`


### PR DESCRIPTION
Found a small issue with upgrading and installing Unison, where both upgrade and install appears with the same error as below

```
→ Fetching unisonweb/unison/unison-language
→ Downloading https://github.com/unisonweb/unison/releases/download/release%2F0.5.21/ucm-macos.tar.gz
→ Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/35164952/e34e
###########################################
## 100.0%
Error: unison-language: SHA256 mismatch
Expected: cfce15e43e1162eeed7cf4eaaac2dcb5f12f45356b12c3a6a5c37dc357a747a9
Actual: 02d2e4Cbc45ebd14406450331b3e14a968413fe426fe446ee1f313771f4a07ec
File: /Users/ethanmorgan/Library/Caches/Homebrew/downloads/9b55783010ac7f57a0b849499d19dlafd5e242f44ebbdf49
31ea8e7acc7addd7--ucm-macos.tar. gz
To retry an incomplete download, remove the file above.
```

The readme change provides a quick fix that resolved my issue and hopefully others